### PR TITLE
make black and white triangles equal in size

### DIFF
--- a/mpchess.mp
+++ b/mpchess.mp
@@ -734,8 +734,8 @@ def _int_to_piece(expr i)=
     fi
 enddef;
 
-def _triangle(expr s)=
-    ((0,0)--(1,0)--(0.5,0.5)--cycle) scaled (s*_chessSquareU)
+def _triangle(expr s, r)=
+        ((0,0)--(1,0)--(0.5,0.5)--cycle) if r: rotatedaround((0.5, 0.5/3), 180) fi scaled (s*_chessSquareU)
 enddef;
 
 color _chess_last_move_color;
@@ -786,15 +786,17 @@ vardef _chess_build_chessboard_pic(expr k)=
     if(_show_whos_to_move):
         if(_chess_view_wb): %white side 
             if(not _white_to_move):
-                fill _triangle(0.3) rotated 180  shifted (_chessSquareU*(_chessSize+0.35),_chessSquareU*(_chessSize)+0.3*_chessSquareU)
+                draw _triangle(0.35,true) shifted (_chessSquareU*(_chessSize+0.3),_chessSquareU*(_chessSize)+0.3*_chessSquareU) ;
+                fill _triangle(0.35,true) shifted (_chessSquareU*(_chessSize+0.3),_chessSquareU*(_chessSize)+0.3*_chessSquareU) ;
             else:
-                draw _triangle(0.35)  shifted (_chessSquareU*(_chessSize+0.3),-0.3*_chessSquareU) ;
+                draw _triangle(0.35,false)  shifted (_chessSquareU*(_chessSize+0.3),-0.3*_chessSquareU) ;
             fi
         else: % black side
             if(_white_to_move):
-                draw _triangle(0.3) rotated 180  shifted (_chessSquareU*(_chessSize+0.35),_chessSquareU*(_chessSize)+0.3*_chessSquareU)
+                draw _triangle(0.35,true) shifted (_chessSquareU*(_chessSize+0.3),_chessSquareU*(_chessSize)+0.3*_chessSquareU) ;
             else:
-                fill _triangle(0.35)  shifted (_chessSquareU*(_chessSize+0.3),-0.3*_chessSquareU) ;
+                draw _triangle(0.35,false)  shifted (_chessSquareU*(_chessSize+0.3),-0.3*_chessSquareU) ;
+                fill _triangle(0.35,false)  shifted (_chessSquareU*(_chessSize+0.3),-0.3*_chessSquareU) ;
             fi
         fi
     fi


### PR DESCRIPTION
Currently the black and white triangles have
different dimentions and horizontal positions.
This leads to figures with differnt widths
which is kind of unexpected and annoying to
align. For example:

\documentclass{article}
\usepackage{luamplib}

\def\foo#1{
\begin{mplibcode}
input mpchess;
beginfig(0);
set_backboard_width(4cm)
init_backboard;
draw backboard;
string fenstr;
fenstr := "#1";
build_chessboard_from_fen(fenstr);
draw chessboard;
endfig;
\end{mplibcode}}

\begin{document}
\begin{tabular}{cc}
\foo{6k1/5ppp/8/2r5/8/7P/5PP1/3R2K1 w - - 0 1} & \foo{3r2k1/3R1ppp/6b1/q7/3Q4/7P/5PPB/6K1 b - - 0 1}\\ \foo{r1r3k1/3R1ppp/8/5n2/8/6P1/5PBP/3R2K1 w - - 0 1} & \foo{6k1/5ppp/8/2r5/8/7P/5PP1/3R2K1 w - - 0 1} \end{tabular}
\end{document}

This commit will fix the horizontal alignment.
Maybe an option to put the triangle on the side,
to avoid problems with vertical alignment will
be a good idea (or even a way to customize the
marker shape and location in genral).